### PR TITLE
Set gem version in x2ch/version.rb for DRY

### DIFF
--- a/lib/x2ch.rb
+++ b/lib/x2ch.rb
@@ -3,6 +3,7 @@
 require 'open-uri'
 require 'kconv'
 require 'zlib'
+require 'x2ch/version'
 
 module X2CH
   class Bbs
@@ -112,7 +113,7 @@ module X2CH
 
   class Agent
     def self.download(url, if_modified_since = nil, range = nil)
-      header = {"User-Agent" => "Monazilla/1.00 (x2ch/0.9.1)", "Accept-Encoding" => 'gzip'}
+      header = {"User-Agent" => "Monazilla/1.00 (x2ch/#{X2CH::VERSION})", "Accept-Encoding" => 'gzip'}
       if if_modified_since
         header["If-Modified-Since"] = if_modified_since
       end

--- a/lib/x2ch/version.rb
+++ b/lib/x2ch/version.rb
@@ -1,0 +1,3 @@
+module X2CH
+  VERSION = "0.9.3"
+end

--- a/x2ch.gemspec
+++ b/x2ch.gemspec
@@ -1,12 +1,16 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'x2ch/version'
+
 Gem::Specification.new do |s|
   s.name        = 'x2ch'
-  s.version     = '0.9.3'
+  s.version     = X2CH::VERSION
   s.date        = '2015-03-26'
   s.summary     = "2ch.sc downloader and parser library"
   s.description = "2ch.sc downloader and parser library"
   s.authors     = ["xmisao"]
   s.email       = 'mail@xmisao.com'
-  s.files       = ["lib/x2ch.rb"]
+  s.files       = ["lib/x2ch.rb", "lib/x2ch/version.rb"]
   s.homepage    = 'https://github.com/xmisao/x2ch'
 	s.license     = 'MIT'
 end


### PR DESCRIPTION
Gem version was separately set in x2ch.gemspec and User-Agent in X2CH::Agent.download. It is error-prone.

This commit defines gem version in x2ch/version.rb as X2CH::VERSION and makes x2ch.gemspec and X2CH::Agent.download refer it.
